### PR TITLE
fixes and suggestions for challenge

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,17 +151,17 @@ a number of state variables:
     - `camera.values` (walls color, n=resolution=64)
  - `position` (initially 0.5, 0.5, task dependent)
  - `direction` (inititally 90° ± 5°, task dependent)
- - `energy` (initially 1000)
- - `move_penalty` (constant, 1)
- - `hit_penalty` (constant, 5)
+ - `energy` (initially 1)
+ - `move_penalty` (constant, 1/1000)
+ - `hit_penalty` (constant, 5/1000)
 
 as well as the Environment (task dependent) class that also gives access to energy sources:
 
- - `energy` (initially 2000)
+ - `energy` (initially 2)
  - `probability` (constant, 1.0, task & source dependent)
  - `quality` (constant, 1.0, task & source dependent)
- - `leak` (constant, 2)
- - `refill` (constant, 5)
+ - `leak` (constant, 2/1000)
+ - `refill` (constant, 5/1000)
 
 These variables can be read (and possibly modified) during training but they won't be accessible during testing (no reading, no writing). To actually move the bot, you need to call the `forward` method. This method first changes the direction of the bot and then move it forward and update the internal state (sensors, hit detection, energy consumption). The evaluation method has also a debug flag that may be helpful to visualize the behavior of your model (see Figure 2).
 
@@ -210,7 +210,7 @@ below.
 Author     | Date       | File        | Score                  | Seed   | Description
 ---------- | ---------- | ----------- | -----------------------|------- | -------------------------
 [@rougier] | 07/06/2025 | [manual.py] | **15.00** (single run) | None   | Manual player (reference)
-[@rougier] | 01/06/2025 | [random.py] |  **0.62** ± 0.37       | 12345  | Stupid random bot
+[@rougier] | 01/06/2025 | [random.py] |  **1.05** ±  0.54       | 12345  | Stupid random bot
 
 
 [@rougier]: https://github.com/rougier

--- a/braincraft/bot.py
+++ b/braincraft/bot.py
@@ -17,11 +17,11 @@ class Bot:
     speed: float                   = 0.01
     camera: Camera                 = Camera(fov=60, resolution=64)
     hit: int                       = 0
-    energy: int                    = 1000
+    energy: int                    = 1
     energy_min: int                = 0
-    energy_max: int                = 1000
-    energy_move: int               = 1
-    energy_hit: int                = 5
+    energy_max: int                = 1
+    energy_move: float             = 1/1000
+    energy_hit: float              = 5/1000
 
 
     def __post_init__(self):

--- a/braincraft/challenge.py
+++ b/braincraft/challenge.py
@@ -179,9 +179,11 @@ def evaluate(model, Bot, Environment, runs=10, seed=None, debug=False):
                     graphics["energy"].set_segments([[(0.1, 0.1),(0.9, 0.1)],
                                                      [(0.1, 0.1),(0.9, 0.1)]])            
                 graphics["camera"].set_data(bot.camera.framebuffer)
+                bot.camera.render(bot.position, bot.direction,
+                              environment.world, environment.colormap)
                 plt.pause(1/60)
 
-            scores.append (distance)
+        scores.append(distance)
 
     return np.mean(scores), np.std(scores)
 

--- a/braincraft/environment_1.py
+++ b/braincraft/environment_1.py
@@ -15,12 +15,12 @@ class Source:
     by a negative number (identity).
     """
 
-    identity: int                   # Identity of the source (mandatory & negative)
-    energy: int        = 2000       # Initial energy level
-    probability: float = 1.0        # Probability of refill
-    quality: int       = 1          # Quality of the source (1, 2, or 3)
-    leak: int          = 2          # Source leak per iteration
-    refill: int        = 5          # Refill amount for the bot
+    identity: int                       # Identity of the source (mandatory & negative)
+    energy: int         = 2             # Initial energy level
+    probability: float  = 1.0           # Probability of refill
+    quality: int        = 1             # Quality of the source (1, 2, or 3)
+    leak: float         = 2/1000        # Source leak per iteration
+    refill: float       = 5/1000        # Refill amount for the bot
 
     def update(self):
         """Update source energy level"""


### PR DESCRIPTION
- made the right screen (bot view) render in debug mode

- corrected the distance calculation in the evaluation function, since it was appending distances each iteration instead of the final distance achieved for each run

- scaled down bot energy from 1000 to 1 for better reservoir dynamics, since the rest of the input is between 0 and 1, this big value makes training rather difficult. I have manually adjusted my `Win` to account for this, but I get the best results by just scaling down the value for the Bot and Environment itself. 
(This could probably also be done simpler in the evaluate function, so 
in line 152 of `challenge.py` with 
`I[n:,0] = bot.hit, bot.energy, 1.0` 
to 
`I[n:,0] = bot.hit, bot.energy / 1000 , 1.0` 
, but might be less intuitive without an explanation.)

Since these changes influence the performance of the bots, some changes need to be made to the readme as well, so the score for the random bot changes to `1.05 ± 0.54` and the explanations itself at some points change too.