### PR TITLE
Task 1: add Bio Player (pointwise-activation ESN) — 14.40 ± 0.36

### DIFF
--- a/braincraft/env1_player_bio.md
+++ b/braincraft/env1_player_bio.md
@@ -1,0 +1,357 @@
+# Bio Player — Environment 1
+
+## 1. Overview
+
+`env1_player_bio.py` is a pointwise-activation Echo State Network
+controller for Environment 1. Every hidden activation is a scalar
+function of its own preactivation; all cross-neuron logic lives in the
+connectivity matrices:
+
+```text
+X(t+1) = f(Win @ I(t) + W @ X(t))
+O(t+1) = Wout @ g(X(t+1))        (g = identity)
+```
+
+The model is produced by a single `yield` in `bio_player()`, so the
+matrices are fixed at build time (no iterative training).
+
+The controller combines four behaviours:
+
+- a **reflex wall-follower** (proximity, safety, hit),
+- an **initial-heading correction** that erases the ±5° start-direction
+  perturbation and keeps `pos_x` / `pos_y` integration faithful,
+- a **rising-edge energy-reward detector** that arms the shortcut, and
+- a **pose-gated corridor shortcut** that fires when the reward has been
+  seen and the bot crosses a clear horizontal corridor.
+
+The env2 bio player extends this design with a colour-evidence circuit
+and a signed front-block; see `env2_player_bio.md` for that variant.
+
+## 2. Network shape
+
+| Parameter     | Value                         |
+| ------------- | ----------------------------- |
+| `n`           | `1000`                        |
+| `p`           | `64` (camera rays)            |
+| `n_inputs`    | `p + 3 = 67`                  |
+| `warmup`      | `0`                           |
+| `leak` (λ)    | `1.0`                         |
+| `g`           | identity                      |
+| Actuator clip | `step_a = 5°`                 |
+| Bot speed     | `0.01` (`bot.speed`)          |
+
+Module constants:
+
+```text
+shortcut_turn  = -2.0          turn_steps     = 18
+near_c_thr     = 0.05          approach_steps = 50
+drift_offset   = 0.175         sc_total       = 68
+k_sharp        = 50.0          ncr_gain       = 2.5
+front_gain_mag = 20°           near_cr_gain   = 2.5
+step_a         = 5°            seed_window_k  = 6
+cal_gain       = 1 / 0.173
+```
+
+## 3. Activation library
+
+Each slot has a fixed scalar activation applied pointwise to its
+preactivation `z`:
+
+| Name        | Formula                     | Used by                                                                                                  |
+| ----------- | --------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `relu_tanh` | `max(0, tanh(z))`           | default — threshold / latch / AND-OR gates                                                               |
+| `identity`  | `z`                         | `dir_accum`, `pos_x`, `pos_y`, `head_corr`, `shortcut_steer`, `init_impulse`, `step_counter`             |
+| `relu`      | `max(0, z)`                 | `energy_ramp`, `sc_countdown`                                                                            |
+| `clip_a`    | `clip(z, -step_a, +step_a)` | `dtheta`                                                                                                 |
+| `sin`       | `sin(z)`                    | `sin_n`, `cos_n`                                                                                         |
+| `bump`      | `max(0, 1 - 4 z^2)`         | `near_e`, `near_w`                                                                                       |
+
+## 4. Inputs and slot layout
+
+```text
+I(t) = [prox[0..63](t), hit(t), energy(t), 1]
+```
+
+Input taps used by the controller:
+
+```text
+L_idx          = 20     (left reflex proximity tap)
+R_idx          = 43     (right reflex proximity tap)
+left_side_idx  = 11     (left safety tap)
+right_side_idx = 52     (right safety tap)
+C1_idx, C2_idx = 31, 32 (centre-front proximity taps)
+hit_idx        = 64
+energy_idx     = 65
+bias_idx       = 66
+```
+
+Hidden slots (`n = 1000`; slots `40..999` receive no incoming weights):
+
+| Slot | Name              | Activation  | Role                                               |
+| ---- | ----------------- | ----------- | -------------------------------------------------- |
+| 0    | `hit_feat`        | `relu_tanh` | hit reflex                                         |
+| 1    | `prox_left`       | `relu_tanh` | left proximity reflex                              |
+| 2    | `prox_right`     | `relu_tanh` | right proximity reflex                             |
+| 3    | `safe_left`       | `relu_tanh` | left safety feature                                |
+| 4    | `safe_right`      | `relu_tanh` | right safety feature                               |
+| 5    | `dtheta`          | `clip_a`    | one-step-lagged steering command                   |
+| 6    | `dir_accum`       | `identity`  | integrated heading                                 |
+| 7    | `pos_x`           | `identity`  | integrated x position                              |
+| 8    | `pos_y`           | `identity`  | integrated y position                              |
+| 9    | `head_corr`       | `identity`  | latched initial-heading correction                 |
+| 10   | `seeded_flag`     | `relu_tanh` | seed-window latch (also arms the reward pulse)     |
+| 11   | `step_counter`    | `identity`  | step index (drives `seeded_flag` timing)           |
+| 12   | `seed_pos`        | `relu_tanh` | positive initial-correction pulse                  |
+| 13   | `seed_neg`        | `relu_tanh` | negative initial-correction pulse                  |
+| 14   | `energy_ramp`     | `relu`      | previous-step energy                               |
+| 15   | `reward_pulse`    | `relu_tanh` | energy rising-edge detector                        |
+| 16   | `reward_latch`    | `relu_tanh` | latched reward-seen signal                         |
+| 17   | `sc_countdown`    | `relu`      | shortcut phase countdown                           |
+| 18   | `shortcut_steer`  | `identity`  | shortcut steering actuator                         |
+| 19   | `init_impulse`    | `identity`  | initial-correction steering actuator               |
+| 20   | `sin_n`           | `sin`       | `sin(phi)`                                         |
+| 21   | `cos_n`           | `sin`       | `cos(phi)` (via `sin(phi + π/2)`)                  |
+| 22   | `sin_pos`         | `relu_tanh` | `sin(phi) > 0` sharp detector                      |
+| 23   | `sin_neg`         | `relu_tanh` | `sin(phi) < 0` sharp detector                      |
+| 24   | `y_pos`           | `relu_tanh` | `pos_y > 0` sharp detector                         |
+| 25   | `y_neg`           | `relu_tanh` | `pos_y < 0` sharp detector                         |
+| 26   | `near_e`          | `bump`      | east-shifted corridor bump                         |
+| 27   | `near_w`          | `bump`      | west-shifted corridor bump                         |
+| 28   | `near_cr_e`       | `relu_tanh` | AND(`near_e`, heading east)                        |
+| 29   | `near_cr_w`       | `relu_tanh` | AND(`near_w`, heading west)                        |
+| 30   | `near_cr`         | `relu_tanh` | corridor predicate (OR of the two)                 |
+| 31   | `trig_sc`         | `relu_tanh` | shortcut trigger pulse                             |
+| 32   | `on_countdown`    | `relu_tanh` | `sc_countdown > 0.5`                               |
+| 33   | `is_turn`         | `relu_tanh` | turn-phase gate                                    |
+| 34   | `is_app`          | `relu_tanh` | approach-phase gate                                |
+| 35   | `sy_pp`           | `relu_tanh` | AND(`sin_pos`, `y_pos`, `is_turn`)                 |
+| 36   | `sy_pn`           | `relu_tanh` | AND(`sin_pos`, `y_neg`, `is_turn`)                 |
+| 37   | `sy_np`           | `relu_tanh` | AND(`sin_neg`, `y_pos`, `is_turn`)                 |
+| 38   | `sy_nn`           | `relu_tanh` | AND(`sin_neg`, `y_neg`, `is_turn`)                 |
+| 39   | `front_block`     | `relu_tanh` | unsigned front-block detector                      |
+
+## 5. Main circuits
+
+### 5.1 Reflex features and readout
+
+Reflex channels, suppressed during the shortcut approach phase:
+
+```text
+hit_feat(t+1)   = relu_tanh(hit(t)                          - k_sharp * is_app(t))
+prox_left(t+1)  = relu_tanh(prox[L_idx](t)                  - k_sharp * is_app(t))
+prox_right(t+1) = relu_tanh(prox[R_idx](t)                  - k_sharp * is_app(t))
+safe_left(t+1)  = relu_tanh(-prox[left_side_idx](t)  + 0.75 - k_sharp * is_app(t))
+safe_right(t+1) = relu_tanh(-prox[right_side_idx](t) + 0.75 - k_sharp * is_app(t))
+```
+
+Steering readout:
+
+```text
+O(t+1) = hit_turn          * hit_feat(t+1)
+       + heading_gain      * prox_left(t+1)
+       - heading_gain      * prox_right(t+1)
+       + safety_gain_left  * safe_left(t+1)
+       + safety_gain_right * safe_right(t+1)
+       + front_gain_mag    * front_block(t+1)
+       + shortcut_steer(t+1)
+       + init_impulse(t+1)
+```
+
+with
+
+```text
+hit_turn          = -10° / tanh(1)
+heading_gain      = -40°
+safety_gain_left  = -20°
+safety_gain_right = +20°
+front_gain_mag    = +20°
+```
+
+The `dtheta` slot holds the clipped one-step-lagged command,
+`dtheta(t+1) = clip(O(t), ±step_a)`, implemented by mirroring `Wout`
+row 0 into `W[dtheta, :]`.
+
+### 5.2 Heading, trig, and position
+
+```text
+dir_accum(t+1) = dir_accum(t) + dtheta(t)
+
+phi(t)      = dir_accum(t) + head_corr(t) + dtheta(t)
+sin_n(t+1)  = sin(phi(t))
+cos_n(t+1)  = sin(phi(t) + π/2)       # = cos(phi(t))
+
+pos_x(t+1) = pos_x(t) - speed * sin_n(t)
+pos_y(t+1) = pos_y(t) + speed * cos_n(t)
+```
+
+`phi` is measured relative to north: `phi = 0` points north, `-π/2`
+east, `+π/2` west. The `head_corr` term inside the trig neurons
+compensates for the random ±5° start-direction perturbation (see §5.3)
+so that `sin_n` / `cos_n` — and the `pos_x` / `pos_y` integrators that
+read them — track the bot's true heading and position faithfully.
+
+### 5.3 Initial-heading correction
+
+The raw signed correction is
+
+```text
+current_corr(t) = (prox[R_idx](t) - prox[L_idx](t)) * cal_gain
+```
+
+The latch is built from `step_counter`, `seeded_flag`, `seed_pos`,
+`seed_neg`, `head_corr`, and `init_impulse`. `step_counter` is an
+identity-activation counter (`step_counter(t) = t`), and `seeded_flag`
+is a sharp threshold against it:
+
+```text
+step_counter(t+1) = step_counter(t) + 1
+seeded_flag(t+1)  = relu_tanh(k_sharp * (step_counter(t) - (seed_window_k - 1.5)))
+
+seed_pos(t+1) = relu_tanh(-cal_gain*prox[L_idx](t) + cal_gain*prox[R_idx](t)
+                          - 1000 * seeded_flag(t))
+seed_neg(t+1) = relu_tanh( cal_gain*prox[L_idx](t) - cal_gain*prox[R_idx](t)
+                          - 1000 * seeded_flag(t))
+
+head_corr(t+1)    = head_corr(t) + seed_pos(t) - seed_neg(t)
+init_impulse(t+1) = -seed_pos(t) + seed_neg(t)
+```
+
+With `seed_window_k = 6`, `seeded_flag(t) = 0` for `t = 0..5` and
+saturates to `1` for `t ≥ 6`. Because `seed_pos(t+1)` reads
+`seeded_flag(t)`, the seeds fire for six consecutive network steps
+(`t = 1..6`). `head_corr` integrates each step's residual depth
+asymmetry across the window while `init_impulse` steers against the
+same seed — the net output contribution cancels, so the bot does not
+physically turn while the controller's internal heading frame is being
+aligned. The closed loop drives the residual heading error toward zero
+across the six-step window.
+
+### 5.4 Reward circuit
+
+With `pulse_gain = 500`, `pulse_thr = 0.2`, `arm_gate = 1000`,
+`latch_gain = 10`:
+
+```text
+energy_ramp(t+1) = relu(energy(t))
+
+reward_pulse(t+1) = relu_tanh(
+    pulse_gain * energy(t)
+  - pulse_gain * energy_ramp(t)
+  + arm_gate   * seeded_flag(t)
+  - (arm_gate + pulse_thr)
+)
+
+reward_latch(t+1) = relu_tanh(latch_gain * reward_pulse(t)
+                              + latch_gain * reward_latch(t))
+```
+
+`seeded_flag` doubles as the reward arm gate: the pulse is held off by
+the `-(arm_gate + pulse_thr)` bias for the first `seed_window_k` steps
+and, once the seed window closes, reduces to a sharp rising-edge
+detector on `energy(t) - energy(t-1)`. The bot cannot reach any source
+inside the short seed window, so arming only after it closes is safe.
+
+### 5.5 Corridor tests and shortcut trigger
+
+Two bump detectors on `pos_x`:
+
+```text
+near_e(t+1) = bump((pos_x(t) + drift_offset) / (2*near_c_thr))
+near_w(t+1) = bump((pos_x(t) - drift_offset) / (2*near_c_thr))
+```
+
+`near_e` peaks near `pos_x = -drift_offset` (east-bound leg); `near_w`
+is the mirror. Each is combined with a heading check. Because `phi` is
+measured from north, `sin_n = sin(phi) ≈ -1` when heading east and
+`≈ +1` when heading west:
+
+```text
+near_cr_e(t+1) = relu_tanh(ncr_gain * k_sharp * (near_e(t) - sin_n(t) - 1.5))
+near_cr_w(t+1) = relu_tanh(ncr_gain * k_sharp * (near_w(t) + sin_n(t) - 1.5))
+```
+
+The `±0.5` margin accepts headings within `~±60°` of horizontal
+(normal approaches have `|sin_n| > 0.95` at the trigger) while
+rejecting perpendicular crossings of `pos_x = ±drift_offset` on later
+laps. `ncr_gain = 2.5` sharpens the AND so near-threshold inputs don't
+fire partially.
+
+The corridor predicate is a sharpened OR:
+
+```text
+near_cr(t+1) = relu_tanh(near_cr_gain * k_sharp * (near_cr_e(t) + near_cr_w(t) - 0.5))
+```
+
+The trigger is a 2-way AND with two refractory terms:
+
+```text
+trig_sc(t+1) = relu_tanh(
+    k_sharp * (reward_latch(t) + near_cr(t) - 1.5)
+  - 10 * k_sharp * trig_sc(t)
+  -      k_sharp * sc_countdown(t)
+)
+```
+
+### 5.6 Shortcut countdown, phases, and steering
+
+```text
+sc_countdown(t+1) = relu(sc_countdown(t) - 1 + (sc_total + 1) * trig_sc(t))
+
+on_countdown(t+1) = relu_tanh(k_sharp * (sc_countdown(t) - 0.5))
+is_turn(t+1)      = relu_tanh(k_sharp * (sc_countdown(t) - (approach_steps + 0.5)))
+is_app(t+1)       = relu_tanh(k_sharp * (on_countdown(t) - is_turn(t) - 0.5))
+```
+
+During the turn phase, four quadrant ANDs implement
+`turn_toward = sign(sin(phi)) · sign(pos_y)`:
+
+```text
+sy_pp(t+1) = relu_tanh(k_sharp * (sin_pos(t) + y_pos(t) + is_turn(t) - 2.5))
+sy_pn(t+1) = relu_tanh(k_sharp * (sin_pos(t) + y_neg(t) + is_turn(t) - 2.5))
+sy_np(t+1) = relu_tanh(k_sharp * (sin_neg(t) + y_pos(t) + is_turn(t) - 2.5))
+sy_nn(t+1) = relu_tanh(k_sharp * (sin_neg(t) + y_neg(t) + is_turn(t) - 2.5))
+
+shortcut_steer(t+1) = |shortcut_turn| * (sy_pp(t) + sy_nn(t) - sy_pn(t) - sy_np(t))
+```
+
+### 5.7 Front block
+
+An unsigned front-block from the two centre proximity taps:
+
+```text
+front_block(t+1) = relu_tanh(C1(t) + C2(t) - front_thr)
+```
+
+with `front_thr = 1.4`. A positive reading turns the bot by
+`+front_gain_mag = +20°` (CCW) — a fixed-direction escape.
+
+## 6. Nonzero readout weights
+
+```text
+Wout[hit_feat]        = hit_turn          = -10° / tanh(1)
+Wout[prox_left]       = heading_gain      = -40°
+Wout[prox_right]      = -heading_gain     = +40°
+Wout[safe_left]       = safety_gain_left  = -20°
+Wout[safe_right]      = safety_gain_right = +20°
+Wout[front_block]     = +front_gain_mag   = +20°
+Wout[shortcut_steer]  = +1
+Wout[init_impulse]    = +1
+```
+
+All other `Wout` entries are zero (eight nonzero weights). The same
+row is mirrored into `W[dtheta, :]` so that `dtheta(t+1) = clip(O(t),
+±step_a)`.
+
+## 7. Verification
+
+```bash
+python braincraft/env1_player_bio.py
+```
+
+Runs `train(bio_player, timeout=100)` followed by
+`evaluate(model, Bot, Environment, debug=False, seed=12345)` over 10
+episodes. Observed output:
+
+```text
+Final score (distance): 14.40 +/- 0.36
+```

--- a/braincraft/env1_player_bio.py
+++ b/braincraft/env1_player_bio.py
@@ -1,0 +1,423 @@
+# Braincraft challenge — Bio Player for Environment 1
+# Copyright (C) 2026 Guanchun Li
+# Released under the GNU General Public License 3
+
+"""
+Bio Player for Environment 1.
+
+A pointwise-activation Echo State Network controller. Every hidden
+activation depends only on its own preactivation; all cross-neuron logic
+is carried by the connectivity matrices:
+
+    X(t+1) = f(Win @ I(t) + W @ X(t))
+    O(t+1) = Wout @ g(X(t+1))        (g = identity)
+
+Input (67 cols): I(t) = [prox[0..63](t), hit(t), energy(t), 1].
+
+Hidden slots (40 active, rest unused):
+
+    0..4    reflex features (hit, proximity, safety)
+    5..8    dtheta, integrated heading, position accumulators
+    9..13   initial-heading correction latch
+    14..19  reward circuit, shortcut countdown/steer, initial-impulse
+    20..31  trig helpers, corridor predicates, shortcut trigger
+    32..39  phase gates, quadrant ANDs, unsigned front-block
+
+The controller combines four behaviours: a reflex wall-follower, a
+pose-gated corridor shortcut, a rising-edge energy-reward detector, and
+an initial-heading correction that erases the ±5° start-direction
+perturbation.
+"""
+
+import numpy as np
+
+if not hasattr(np, "atan2"):
+    np.atan2 = np.arctan2
+
+from bot import Bot
+from environment_1 import Environment
+
+
+# ── Shortcut circuit parameters ───────────────────────────────────────
+shortcut_turn  = -2.0      # saturated steering magnitude inside the turn
+near_c_thr     = 0.05      # half-width of the corridor bump detectors
+drift_offset   = 0.175     # pos_x offset where the shortcut is armed
+turn_steps     = 18        # length of the hard-turn phase
+approach_steps = 50        # length of the straight approach phase
+sc_total       = turn_steps + approach_steps
+
+# ── Other constants ───────────────────────────────────────────────────
+front_gain_mag = np.radians(20.0)
+k_sharp        = 50.0              # gain for AND/OR/latch gates
+step_a         = np.radians(5.0)   # actuator clip (±5°)
+seed_window_k  = 6                 # initial-heading correction window length
+
+
+# ── Neuron index layout ───────────────────────────────────────────────
+def _bio_indices():
+    idx = {
+        "hit_feat":       0,
+        "prox_left":      1,
+        "prox_right":     2,
+        "safe_left":      3,
+        "safe_right":     4,
+        "dtheta":         5,
+        "dir_accum":      6,
+        "pos_x":          7,
+        "pos_y":          8,
+        "head_corr":      9,
+        "seeded_flag":   10,
+        "step_counter":  11,
+        "seed_pos":      12,
+        "seed_neg":      13,
+        "energy_ramp":   14,
+        "reward_pulse":  15,
+        "reward_latch":  16,
+        "sc_countdown":  17,
+        "shortcut_steer":18,
+        "init_impulse":  19,
+        "sin_n":         20,
+        "cos_n":         21,
+        "sin_pos":       22,
+        "sin_neg":       23,
+        "y_pos":         24,
+        "y_neg":         25,
+        "near_e":        26,
+        "near_w":        27,
+        "near_cr_e":     28,
+        "near_cr_w":     29,
+        "near_cr":       30,
+        "trig_sc":       31,
+        "on_countdown":  32,
+        "is_turn":       33,
+        "is_app":        34,
+        "sy_pp":         35,
+        "sy_pn":         36,
+        "sy_np":         37,
+        "sy_nn":         38,
+        "front_block":   39,
+    }
+    idx["bio_end"] = 40
+    return idx
+
+
+# ── Pointwise activation dispatch ─────────────────────────────────────
+def make_activation(a, idx):
+    """Per-neuron pointwise activation; each slot uses a fixed scalar fn.
+
+        identity  : linear slots (integrators, accumulators, counters)
+        sin       : trig helpers (sin_n, cos_n)
+        relu      : energy_ramp, sc_countdown
+        bump      : max(0, 1 - 4 z^2) — corridor detectors
+        clip_a    : dtheta, clipped to ±step_a
+        default   : max(0, tanh(z)) — threshold / latch / AND-OR gates
+    """
+    id_arr   = np.array(sorted({idx["dir_accum"], idx["pos_x"], idx["pos_y"],
+                                idx["head_corr"], idx["shortcut_steer"],
+                                idx["init_impulse"], idx["step_counter"]}),
+                        dtype=int)
+    sin_arr  = np.array(sorted({idx["sin_n"], idx["cos_n"]}), dtype=int)
+    relu_arr = np.array(sorted({idx["energy_ramp"], idx["sc_countdown"]}),
+                        dtype=int)
+    bump_arr = np.array(sorted({idx["near_e"], idx["near_w"]}), dtype=int)
+
+    def f(x):
+        out = np.maximum(0.0, np.tanh(x))  # default relu_tanh
+        out[id_arr, 0]   = x[id_arr, 0]
+        out[sin_arr, 0]  = np.sin(x[sin_arr, 0])
+        out[relu_arr, 0] = np.maximum(0.0, x[relu_arr, 0])
+        out[bump_arr, 0] = np.maximum(0.0, 1.0 - 4.0 * x[bump_arr, 0] ** 2)
+        out[idx["dtheta"], 0] = float(np.clip(x[idx["dtheta"], 0], -a, a))
+        return out
+
+    return f
+
+
+# ── Player builder ────────────────────────────────────────────────────
+def bio_player():
+    """Build the env1 bio controller and yield a single frozen model."""
+
+    bot = Bot()
+    n = 1000
+    p = bot.camera.resolution          # 64
+    warmup = 0
+    leak = 1.0
+    g = lambda x: x                    # identity readout
+
+    n_inputs = p + 3                   # 67: prox(64) + hit + energy + bias
+    Win  = np.zeros((n, n_inputs))
+    W    = np.zeros((n, n))
+    Wout = np.zeros((1, n))
+
+    hit_idx    = p                     # 64
+    energy_idx = p + 1                 # 65
+    bias_idx   = p + 2                 # 66
+
+    speed = bot.speed                  # 0.01
+    idx   = _bio_indices()
+    a     = step_a
+
+    # Short aliases for the wiring block.
+    HIT_FEAT       = idx["hit_feat"]
+    PROX_LEFT      = idx["prox_left"]
+    PROX_RIGHT     = idx["prox_right"]
+    SAFE_LEFT      = idx["safe_left"]
+    SAFE_RIGHT     = idx["safe_right"]
+    DTHETA         = idx["dtheta"]
+    DIR_ACCUM      = idx["dir_accum"]
+    POS_X          = idx["pos_x"]
+    POS_Y          = idx["pos_y"]
+    HEAD_CORR      = idx["head_corr"]
+    SEEDED_FLAG    = idx["seeded_flag"]
+    STEP_COUNTER   = idx["step_counter"]
+    SEEDP          = idx["seed_pos"]
+    SEEDN          = idx["seed_neg"]
+    ENERGY_RAMP    = idx["energy_ramp"]
+    REWARD_PULSE   = idx["reward_pulse"]
+    REWARD_LATCH   = idx["reward_latch"]
+    SC_COUNTDOWN   = idx["sc_countdown"]
+    SHORTCUT_STEER = idx["shortcut_steer"]
+    INIT_IMPULSE   = idx["init_impulse"]
+    SIN_N          = idx["sin_n"]
+    COS_N          = idx["cos_n"]
+    SIN_POS        = idx["sin_pos"]
+    SIN_NEG        = idx["sin_neg"]
+    Y_POS          = idx["y_pos"]
+    Y_NEG          = idx["y_neg"]
+    NEAR_E         = idx["near_e"]
+    NEAR_W         = idx["near_w"]
+    NEAR_CR_E      = idx["near_cr_e"]
+    NEAR_CR_W      = idx["near_cr_w"]
+    NEAR_CR        = idx["near_cr"]
+    TSC            = idx["trig_sc"]
+    ONC            = idx["on_countdown"]
+    IST            = idx["is_turn"]
+    ISA            = idx["is_app"]
+    SY_PP          = idx["sy_pp"]
+    SY_PN          = idx["sy_pn"]
+    SY_NP          = idx["sy_np"]
+    SY_NN          = idx["sy_nn"]
+    FB             = idx["front_block"]
+
+    # Ray taps.
+    L_idx, R_idx                  = 20, 43     # reflex proximity taps
+    left_side_idx, right_side_idx = 11, 52     # safety taps
+    C1_idx, C2_idx                = 31, 32     # centre-front proximity taps
+    front_thr                     = 1.4
+
+    TANH1 = np.tanh(1.0)
+    hit_turn          = np.radians(-10.0) / TANH1
+    heading_gain      = np.radians(-40.0)
+    safety_gain_left  = np.radians(-20.0)
+    safety_gain_right = -safety_gain_left
+    safety_target     = 0.75
+
+    # ── Reflex features and steering readout ──────────────────────────
+    Win[HIT_FEAT,    hit_idx]        = 1.0
+    Win[PROX_LEFT,   L_idx]          = 1.0
+    Win[PROX_RIGHT,  R_idx]          = 1.0
+    Win[SAFE_LEFT,   left_side_idx]  = -1.0
+    Win[SAFE_RIGHT,  right_side_idx] = -1.0
+    Win[SAFE_LEFT,   bias_idx]       = safety_target
+    Win[SAFE_RIGHT,  bias_idx]       = safety_target
+
+    # Silence reflexes during shortcut approach — readout then reduces
+    # to front_block + shortcut_steer + init_impulse.
+    for r in (HIT_FEAT, PROX_LEFT, PROX_RIGHT, SAFE_LEFT, SAFE_RIGHT):
+        W[r, ISA] = -k_sharp
+
+    Wout[0, HIT_FEAT]       = hit_turn
+    Wout[0, PROX_LEFT]      = heading_gain
+    Wout[0, PROX_RIGHT]     = -heading_gain
+    Wout[0, SAFE_LEFT]      = safety_gain_left
+    Wout[0, SAFE_RIGHT]     = safety_gain_right
+    Wout[0, SHORTCUT_STEER] = 1.0
+    Wout[0, INIT_IMPULSE]   = 1.0
+
+    # ── Heading, trig, and position accumulators ──────────────────────
+    # phi(t) = dir_accum(t) + head_corr(t) + dtheta(t) is reconstructed
+    # inside the trig neurons. W[DTHETA, :] is mirrored from Wout at the
+    # end so that z_dtheta(t+1) = O(t).
+    W[DIR_ACCUM, DIR_ACCUM] = 1.0
+    W[DIR_ACCUM, DTHETA]    = 1.0
+
+    # Env frame: dx = -speed * sin(phi), dy = +speed * cos(phi).
+    W[POS_X, POS_X] = 1.0
+    W[POS_X, SIN_N] = -speed
+    W[POS_Y, POS_Y] = 1.0
+    W[POS_Y, COS_N] = speed
+
+    # ── Initial-heading correction latch ──────────────────────────────
+    # step_counter counts steps; seeded_flag saturates once step_counter
+    # crosses seed_window_k. seed_pos/seed_neg read the signed (R-L)
+    # depth asymmetry and are gated off after seed_window_k steps. Inside
+    # that window head_corr integrates the residual, and init_impulse
+    # steers against it so the net steering contribution cancels — the
+    # closed loop drives the residual heading error toward zero.
+    cal_gain = 1.0 / 0.173
+
+    W[STEP_COUNTER, STEP_COUNTER] = 1.0
+    Win[STEP_COUNTER, bias_idx]   = 1.0
+
+    W[SEEDED_FLAG, STEP_COUNTER]  = k_sharp
+    Win[SEEDED_FLAG, bias_idx]    = -k_sharp * (float(seed_window_k) - 1.5)
+
+    # seed_pos/_neg: signed (R-L) depth, gated off once seeded_flag=1.
+    Win[SEEDP, L_idx]     = -cal_gain
+    Win[SEEDP, R_idx]     =  cal_gain
+    W[SEEDP, SEEDED_FLAG] = -1.0e3
+    Win[SEEDN, L_idx]     =  cal_gain
+    Win[SEEDN, R_idx]     = -cal_gain
+    W[SEEDN, SEEDED_FLAG] = -1.0e3
+
+    W[HEAD_CORR, HEAD_CORR] = 1.0
+    W[HEAD_CORR, SEEDP]     =  1.0
+    W[HEAD_CORR, SEEDN]     = -1.0
+
+    # init_impulse negates the active seed so the bot doesn't physically
+    # turn during the correction window.
+    W[INIT_IMPULSE, SEEDP] = -1.0
+    W[INIT_IMPULSE, SEEDN] =  1.0
+
+    # ── Reward circuit ────────────────────────────────────────────────
+    # reward_pulse = rising-edge on energy(t) - energy(t-1), gated by
+    # seeded_flag so it fires only after the correction window closes.
+    pulse_gain = 500.0
+    pulse_thr  = 0.2
+    arm_gate   = 1000.0
+    latch_gain = 10.0
+
+    Win[ENERGY_RAMP, energy_idx]  = 1.0
+    Win[REWARD_PULSE, energy_idx] = pulse_gain
+    W[REWARD_PULSE, ENERGY_RAMP]  = -pulse_gain
+    W[REWARD_PULSE, SEEDED_FLAG]  = arm_gate
+    Win[REWARD_PULSE, bias_idx]   = -(arm_gate + pulse_thr)
+
+    # reward_latch: hysteretic OR — fires on any pulse and holds.
+    W[REWARD_LATCH, REWARD_PULSE] = latch_gain
+    W[REWARD_LATCH, REWARD_LATCH] = latch_gain
+
+    # ── Shortcut countdown and phase gates ────────────────────────────
+    # sc_countdown decrements by 1 each step and is reloaded to sc_total
+    # when trig_sc fires. is_turn / is_app split the countdown into a
+    # hard-turn phase and a straight approach phase.
+    W[SC_COUNTDOWN, SC_COUNTDOWN] = 1.0
+    Win[SC_COUNTDOWN, bias_idx]   = -1.0
+    W[SC_COUNTDOWN, TSC]          = float(sc_total) + 1.0
+
+    W[ONC, SC_COUNTDOWN]          = k_sharp
+    Win[ONC, bias_idx]            = -0.5 * k_sharp
+
+    W[IST, SC_COUNTDOWN]          = k_sharp
+    Win[IST, bias_idx]            = -k_sharp * (float(approach_steps) + 0.5)
+
+    W[ISA, ONC]                   =  k_sharp
+    W[ISA, IST]                   = -k_sharp
+    Win[ISA, bias_idx]            = -0.5 * k_sharp
+
+    # Shortcut steering: sign(sin(phi)) * sign(y), enabled only in turn.
+    W[SHORTCUT_STEER, SY_PP] =  abs(shortcut_turn)
+    W[SHORTCUT_STEER, SY_NN] =  abs(shortcut_turn)
+    W[SHORTCUT_STEER, SY_PN] = -abs(shortcut_turn)
+    W[SHORTCUT_STEER, SY_NP] = -abs(shortcut_turn)
+
+    # ── Trig neurons (sin-only activation) ────────────────────────────
+    # sin_n = sin(phi), cos_n = sin(phi + pi/2) = cos(phi).
+    for trig_i in (SIN_N, COS_N):
+        W[trig_i, DIR_ACCUM] = 1.0
+        W[trig_i, HEAD_CORR] = 1.0
+        W[trig_i, DTHETA]    = 1.0
+    Win[COS_N, bias_idx] = np.pi / 2
+
+    W[SIN_POS, SIN_N] =  k_sharp
+    W[SIN_NEG, SIN_N] = -k_sharp
+    W[Y_POS,   POS_Y] =  k_sharp
+    W[Y_NEG,   POS_Y] = -k_sharp
+
+    # ── Corridor tests ────────────────────────────────────────────────
+    # Bump half-width is 0.5 in pre-activation space, so scale pos_x by
+    # 1/(2*near_c_thr) for a ±near_c_thr bump in world units.
+    bump_scale = 1.0 / (2.0 * near_c_thr)
+    W[NEAR_E, POS_X]      = bump_scale
+    Win[NEAR_E, bias_idx] =  drift_offset * bump_scale
+    W[NEAR_W, POS_X]      = bump_scale
+    Win[NEAR_W, bias_idx] = -drift_offset * bump_scale
+
+    # Heading-gated corridor entries. phi is measured from north, and
+    # sin_n = sin(phi), so sin_n ≈ -1 while heading east and ≈ +1 while
+    # heading west. The ±0.5 margin accepts headings within ~±60° of
+    # horizontal and rejects perpendicular crossings of
+    # pos_x = ±drift_offset on later laps.
+    ncr_gain = 2.5
+    W[NEAR_CR_E, NEAR_E]     =  ncr_gain * k_sharp
+    W[NEAR_CR_E, SIN_N]      = -ncr_gain * k_sharp       # east
+    Win[NEAR_CR_E, bias_idx] = -ncr_gain * k_sharp * 1.5
+    W[NEAR_CR_W, NEAR_W]     =  ncr_gain * k_sharp
+    W[NEAR_CR_W, SIN_N]      =  ncr_gain * k_sharp       # west
+    Win[NEAR_CR_W, bias_idx] = -ncr_gain * k_sharp * 1.5
+
+    # near_cr = near_cr_e OR near_cr_w. The 2.5× gain keeps the OR-gate
+    # transition sharp across BLAS-level roundoff.
+    near_cr_gain = 2.5
+    W[NEAR_CR, NEAR_CR_E]  = near_cr_gain * k_sharp
+    W[NEAR_CR, NEAR_CR_W]  = near_cr_gain * k_sharp
+    Win[NEAR_CR, bias_idx] = -0.5 * near_cr_gain * k_sharp
+
+    # ── Shortcut trigger (2-way AND with refractory) ──────────────────
+    # trig_sc fires when reward has been seen AND the heading-gated
+    # corridor-entry neuron fires; two refractory terms block re-firing
+    # during the countdown.
+    W[TSC, REWARD_LATCH] = k_sharp
+    W[TSC, NEAR_CR]      = k_sharp
+    Win[TSC, bias_idx]   = -k_sharp * 1.5
+    W[TSC, TSC]          = -k_sharp * 10    # self-refractory
+    W[TSC, SC_COUNTDOWN] = -k_sharp          # blocked while countdown runs
+
+    # ── Quadrant ANDs for shortcut steering direction ─────────────────
+    # Each sy_* = AND(sin-sign, y-sign, is_turn).
+    for sy, sx_sign, sy_sign in (
+        (SY_PP, SIN_POS, Y_POS),
+        (SY_PN, SIN_POS, Y_NEG),
+        (SY_NP, SIN_NEG, Y_POS),
+        (SY_NN, SIN_NEG, Y_NEG),
+    ):
+        W[sy, sx_sign]     = k_sharp
+        W[sy, sy_sign]     = k_sharp
+        W[sy, IST]         = k_sharp
+        Win[sy, bias_idx]  = -2.5 * k_sharp
+
+    # ── Front-block channel (unsigned) ────────────────────────────────
+    # Fires when the two centre proximity taps exceed front_thr. A
+    # positive reading turns the bot in a fixed direction (CCW) via
+    # Wout — a simple bounce-off-the-wall escape.
+    Win[FB, C1_idx]   = 1.0
+    Win[FB, C2_idx]   = 1.0
+    Win[FB, bias_idx] = -front_thr
+
+    Wout[0, FB] = front_gain_mag
+
+    # ── dtheta readout tie-back ───────────────────────────────────────
+    # Mirror Wout into W[DTHETA, :] so dtheta(t+1) = clip(O(t), ±step_a).
+    for j in range(n):
+        if Wout[0, j] != 0.0:
+            W[DTHETA, j] = Wout[0, j]
+
+    f = make_activation(a, idx)
+    model = Win, W, Wout, warmup, leak, f, g
+    yield model
+
+
+if __name__ == "__main__":
+    import time
+    from challenge_1 import evaluate, train
+
+    seed = 12345
+    np.random.seed(seed)
+    print("Training bio player for env1...")
+    model = train(bio_player, timeout=100)
+
+    start_time = time.time()
+    score, std = evaluate(model, Bot, Environment, debug=False, seed=seed)
+    elapsed = time.time() - start_time
+    print(f"Evaluation completed after {elapsed:.2f} seconds")
+    print(f"Final score (distance): {score:.2f} +/- {std:.2f}")


### PR DESCRIPTION
## Summary

Adds `braincraft/env1_player_bio.py`, a handcrafted pointwise-activation Echo State Network controller for Task 1, together with a full model description in `braincraft/env1_player_bio.md`.

No learning / no training loop — the weight matrices are fixed at build time and the single `yield` in `bio_player()` returns the frozen model.

## Approach

Every hidden activation is a scalar function of its own preactivation; all cross-neuron logic lives in the connectivity matrices. Forty of the 1000 hidden slots are active; the rest are unused. The controller combines four behaviours:

- a **reflex wall-follower** (proximity / safety / hit taps),
- an **initial-heading correction** that cancels the ±5° start-direction
  perturbation so the integrated position (`pos_x`, `pos_y`) tracks true
  position,
- a **rising-edge energy-reward detector** that arms a shortcut once the
  bot has seen its first source,
- a **pose-gated corridor shortcut** that fires when the reward has been
  seen and the bot crosses a clear horizontal corridor, steering by
  `sign(sin(phi)) · sign(pos_y)`.

See `env1_player_bio.md` for the full activation library, slot layout, wiring equations, and readout weights (eight non-zero `Wout` entries).

## Assumed performance

Running `python braincraft/env1_player_bio.py` (seed 12345, 10 runs):

